### PR TITLE
allow to import filters from another interaction into a hash

### DIFF
--- a/lib/active_interaction/filters/hash_filter.rb
+++ b/lib/active_interaction/filters/hash_filter.rb
@@ -25,6 +25,31 @@ module ActiveInteraction
 
     register :hash
 
+    # Import filters from another interaction.
+    #
+    # @param klass [Class] The other interaction.
+    # @param options [Hash]
+    #
+    # @option options [Array<Symbol>, nil] :only Import only these filters.
+    # @option options [Array<Symbol>, nil] :except Import all filters except
+    #   for these.
+    #
+    # @!visibility public
+    def import_filters(klass, options = {}) # rubocop:disable Metrics/AbcSize
+      only = options[:only]
+      except = options[:except]
+      groups = options[:groups] || [klass.to_s.demodulize.underscore.to_sym]
+
+      klass.filters.each do |name, filter|
+        next if only && ![*only].include?(name)
+        next if except && [*except].include?(name)
+
+        options = filter.options.merge(groups: groups)
+        filter_copy = filter.class.new(name, options, &filter.block)
+        filters[name] = filter_copy
+      end
+    end
+
     private
 
     def matches?(value)


### PR DESCRIPTION
This allows composition scenarios like the example bellow:
```
class UserSignUp < ActiveInteraction::Base
  string :email
  string :password
  string :name, default: nil
end

class CreatePost < ActiveInteraction::Base
  object user,
  string :title
  string :body
end

class SignUpAndCreatePost < ActiveInteraction::Base
  hash :user do
    import_filters UserSignUp
  end

  hash :post do
    import_filters CreatePost, except: :user
  end

  def execute
    new_user = compose(UserSignUp, **user.to_options)
    compose(CreatePost, user: new_user, **post.to_options)
  end
end


SignUpAndCreatePost.run!(
  user: {email: "foo@mail.com", password: "secret"}, 
  post: {title: "The News", body: "import_filters from a has is a thing"},
)
```

So far, so good. But I am having a bit of a hard time trying to figure how to write (proper not overly verbose) tests for this.